### PR TITLE
Use epoll reactor to support >1024 descriptors.

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -252,6 +252,7 @@ class MyDataSourcePlugin(PythonDataSourcePlugin):
 
 ;1.6.2
 * Optimize datasource plugin loading. (ZEN-16344)
+* Use epoll reactor to support >1024 descriptors. (ZEN-16164)
 
 ;1.6.1 (2015-01-13)
 * Add container Support for Zenoss 5X (Europa) services including RabbitMQ.

--- a/ZenPacks/zenoss/PythonCollector/zenpython.py
+++ b/ZenPacks/zenoss/PythonCollector/zenpython.py
@@ -21,6 +21,20 @@ import re
 
 import Globals
 
+
+if __name__ == "__main__":
+    # Install the best reactor available if run as a script. This must
+    # be done early before other imports have a chance to install a
+    # different reactor.
+    try:
+        from Products.ZenHub import installReactor
+    except ImportError:
+        # Zenoss 4.1 doesn't have ZenHub.installReactor.
+        pass
+    else:
+        installReactor()
+
+
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.spread import pb


### PR DESCRIPTION
Fixes ZEN-16164.