### PR TITLE
Revert to select reactor. Some plugins require it.

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -250,6 +250,9 @@ class MyDataSourcePlugin(PythonDataSourcePlugin):
 
 == Changes ==
 
+;1.6.3 (2015-02-10)
+* Revert to select reactor. Some plugins require it. (ZEN-16542)
+
 ;1.6.2 (2015-01-27)
 * Optimize datasource plugin loading. (ZEN-16344)
 * Use epoll reactor to support >1024 descriptors. (ZEN-16164)

--- a/ZenPacks/zenoss/PythonCollector/zenpython.py
+++ b/ZenPacks/zenoss/PythonCollector/zenpython.py
@@ -21,20 +21,6 @@ import re
 
 import Globals
 
-
-if __name__ == "__main__":
-    # Install the best reactor available if run as a script. This must
-    # be done early before other imports have a chance to install a
-    # different reactor.
-    try:
-        from Products.ZenHub import installReactor
-    except ImportError:
-        # Zenoss 4.1 doesn't have ZenHub.installReactor.
-        pass
-    else:
-        installReactor()
-
-
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.spread import pb


### PR DESCRIPTION
Specifically in the Layer2 ZenPack where the pynetsnmp library is used
in a zenpython plugin. I can imagine that this won't be the only time
pynetsnmp is used within zenpython.

I can't find any specific cases of the 1024 file descriptor limit
causing problems in zenpython in JIRA. For now if the problem does occur
it could be worked around by deploying another logical collector to
spread the file descriptors between more than one zenpython daemon. In
Zenoss 5 it could be worked around by increasing the number of zenpython
workers.

Fixes ZEN-16542.