### PR TITLE
changed format %d to %%d to match default service definition

### DIFF
--- a/ZenPacks/zenoss/PythonCollector/service_definition/service.json
+++ b/ZenPacks/zenoss/PythonCollector/service_definition/service.json
@@ -179,7 +179,7 @@
                        {
                            "aggregator": "avg",
                            "fill": false,
-                           "format": "%d",
+                           "format": "%%d",
                            "id": "dataPoints",
                            "legend": "Data Points",
                            "metric": "dataPoints",
@@ -206,7 +206,7 @@
                        {
                            "aggregator": "avg",
                            "fill": false,
-                           "format": "%d",
+                           "format": "%%d",
                            "id": "devices",
                            "legend": "Devices",
                            "metric": "devices",
@@ -233,7 +233,7 @@
                        {
                            "aggregator": "avg",
                            "fill": false,
-                           "format": "%d",
+                           "format": "%%d",
                            "id": "eventCount",
                            "legend": "Event Count",
                            "metric": "eventCount",
@@ -260,7 +260,7 @@
                        {
                            "aggregator": "avg",
                            "fill": false,
-                           "format": "%d",
+                           "format": "%%d",
                            "id": "eventQueueLength",
                            "legend": "Event Queue Length",
                            "metric": "eventQueueLength",
@@ -287,7 +287,7 @@
                        {
                            "aggregator": "avg",
                            "fill": false,
-                           "format": "%d",
+                           "format": "%%d",
                            "id": "missedRuns",
                            "legend": "Missed Runs",
                            "metric": "missedRuns",
@@ -314,7 +314,7 @@
                        {
                            "aggregator": "avg",
                            "fill": false,
-                           "format": "%d",
+                           "format": "%%d",
                            "id": "queuedTasks",
                            "legend": "Queued Tasks",
                            "metric": "queuedTasks",
@@ -326,7 +326,7 @@
                        {
                            "aggregator": "avg",
                            "fill": false,
-                           "format": "%d",
+                           "format": "%%d",
                            "id": "runningTasks",
                            "legend": "Running Tasks",
                            "metric": "runningTasks",
@@ -338,7 +338,7 @@
                        {
                            "aggregator": "avg",
                            "fill": false,
-                           "format": "%d",
+                           "format": "%%d",
                            "id": "taskCount",
                            "legend": "Task Count",
                            "metric": "taskCount",


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-17255

match https://github.com/zenoss/zenoss-prodbin/blob/develop/Products/ZenModel/data/default_service.json#L119

DEMO:
```
[root@zsd-5x-demo plu]# serviced service run zope zenpack install ZenPacks.zenoss.PythonCollector-1.6.4-py2.7.egg
I0327 15:52:38.503000 31586 server.go:341] Connected to the control center at port 10.90.34.7:4979
I0327 15:52:38.699147 31586 server.go:435] Acquiring image from the dfs...
I0327 15:52:38.700157 31586 server.go:437] Acquired!  Starting shell
E0327 20:52:39.837222 00001 endpoint.go:514] No proxy for cn9oapalt24beds9jjnml4cui_dynamicserver - no need to set empty address list
E0327 20:52:39.838895 00001 endpoint.go:514] No proxy for cn9oapalt24beds9jjnml4cui_memcached - no need to set empty address list
E0327 20:52:39.839503 00001 endpoint.go:514] No proxy for cn9oapalt24beds9jjnml4cui_zproxy - no need to set empty address list
E0327 20:52:39.839925 00001 endpoint.go:514] No proxy for cn9oapalt24beds9jjnml4cui_localhost_zenhubPB - no need to set empty address list
Trying to connect to logstash server... 127.0.0.1:5042
Connected to logstash server.
INFO:zen.ZenPackCMD:Previous ZenPack exists with same name ZenPacks.zenoss.PythonCollector
INFO:zen.controlplane.client:Removing service euourbidbskwnp0hus33m62bp
INFO:zen.ZenPackCMD:installing zenpack ZenPacks.zenoss.PythonCollector; launching process
2015-03-27 20:53:21,060 INFO zen.ZPLoader: Loading /opt/zenoss/ZenPacks/ZenPacks.zenoss.PythonCollector-1.6.4-py2.7.egg/ZenPacks/zenoss/PythonCollector/objects/objects.xml
2015-03-27 20:53:21,060 INFO zen.AddToPack: End loading objects
2015-03-27 20:53:21,061 INFO zen.AddToPack: Processing links
2015-03-27 20:53:21,302 INFO zen.AddToPack: Loaded 0 objects into the ZODB database
2015-03-27 20:53:21,322 INFO zen.HookReportLoader: Loading reports from /opt/zenoss/ZenPacks/ZenPacks.zenoss.PythonCollector-1.6.4-py2.7.egg/ZenPacks/zenoss/PythonCollector/reports
2015-03-27 20:53:24,515 INFO zen.controlplane.client: Deploying service
2015-03-27 20:53:24,756 INFO zen.controlplane.client: Deploying service
I0327 15:53:30.974361 31586 shell.go:225] Committing container
[root@zsd-5x-demo plu]# exit

```