### PR TITLE
Have datasource component field evaluated as a TALE expression.

### DIFF
--- a/ZenPacks/zenoss/PythonCollector/services/PythonConfig.py
+++ b/ZenPacks/zenoss/PythonCollector/services/PythonConfig.py
@@ -158,7 +158,21 @@ class PythonConfig(CollectorConfigService):
                 ds_config = PythonDataSourceConfig()
                 ds_config.device = deviceId
                 ds_config.manageIp = deviceOrComponent.getManageIp()
-                ds_config.component = componentId
+
+                if isinstance(ds.component,basestring) and '$' in ds.component:
+                        extra = {
+                                    'device': device,
+                                    'dev': device,
+                                    'devname': device.id,
+                                    'datasource': ds,
+                                    'ds': ds,
+                                    'datapoint': dp,
+                                    'dp': dp,
+                        }
+                        ds_config.component = talesEvalStr(ds.component,deviceOrComponent,extra=extra)
+                else:
+                        ds_config.component = componentId
+
                 ds_config.plugin_classname = ds.plugin_classname
                 ds_config.template = template.id
                 ds_config.datasource = ds.titleOrId()


### PR DESCRIPTION
Found a situation where components with the same name did not have differentiated data.

Not sure if there is another way to do this, but I could not figure out how. In the case of 2 components that can have the same name, there needs to be a way to return data values such that each gets the correct data.

In this case, if components A and B are related to other components, C and D, I set the component field in the datasource to be include the name of the additional component as a TALES expression, so the datasource component would be a concatenation of the names for C and A, for example.