### PR TITLE
Switch zenpython back to best (epoll) reactor.

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -257,6 +257,7 @@ class MyDataSourcePlugin(PythonDataSourcePlugin):
 
 ;1.7.1 (2015-07-30)
 * Avoid a tight loop when writing metrics and events. (ZEN-18956)
+* Switch back to epoll reactor. No select-dependent plugins left.
 
 ;1.7.0 (2015-07-06)
 * Fix datapoint format for Control Center metrics.

--- a/ZenPacks/zenoss/PythonCollector/zenpython.py
+++ b/ZenPacks/zenoss/PythonCollector/zenpython.py
@@ -21,6 +21,20 @@ import re
 
 import Globals
 
+
+if __name__ == "__main__":
+    # Install the best reactor available if run as a script. This must
+    # be done early before other imports have a chance to install a
+    # different reactor.
+    try:
+        from Products.ZenHub import installReactor
+    except ImportError:
+        # Zenoss 4.1 doesn't have ZenHub.installReactor.
+        pass
+    else:
+        installReactor()
+
+
 from twisted.internet import reactor, task
 from twisted.internet.defer import inlineCallbacks, returnValue, maybeDeferred
 from twisted.spread import pb


### PR DESCRIPTION
As of Layer2 1.0.3 it no longer requires the select reactor. There are
no other known zenpython plugins that require the select reactor. So we
can safely switch to the epoll reactor to hopefully address some of the
Windows monitoring reliability problems.