### PR TITLE
Fix two 4.1 compatibility issues.

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -309,6 +309,7 @@ class MyDataSourcePlugin(PythonDataSourcePlugin):
 * Add "blockingtimeout" option to zenpython.
 * Add detailed task state tracking to zenpython plugin execution.
 * Add "percentBlocked" metric to zenpython.
+* Restore compatibility with Zenoss 4.1.
 
 ;1.7.1 (2015-07-30)
 * Avoid a tight loop when writing metrics and events. (ZEN-18956)

--- a/ZenPacks/zenoss/PythonCollector/__init__.py
+++ b/ZenPacks/zenoss/PythonCollector/__init__.py
@@ -7,7 +7,20 @@
 #
 ##############################################################################
 
+import Globals  # noqa
+
+from Products.ZenModel.ZenPack import ZenPack as ZenPackBase
 from Products.ZenUtils.Utils import unused
+
+
+class ZenPack(ZenPackBase):
+    def install(self, app):
+        # Our objects.xml assumes the /Zenoss OSProcessOrganizer already
+        # exists. It might not, so we have to create it before calling
+        # super.
+        app.getDmdRoot('Processes').createOrganizer('Zenoss')
+
+        super(ZenPack, self).install(app)
 
 
 # Patch last to avoid import recursion problems.

--- a/ZenPacks/zenoss/PythonCollector/zenpython.py
+++ b/ZenPacks/zenoss/PythonCollector/zenpython.py
@@ -487,7 +487,11 @@ def main():
     task_splitter = PerDataSourceInstanceTaskSplitter(task_factory)
     daemon = CollectorDaemon(preferences, task_splitter)
     pool_size = preferences.options.threadPoolSize
-    reactor.suggestThreadPoolSize(pool_size)
+
+    # The Twisted version shipped with Zenoss 4.1 doesn't have this.
+    if hasattr(reactor, 'suggestThreadPoolSize'):
+        reactor.suggestThreadPoolSize(pool_size)
+
     daemon.run()
 
 


### PR DESCRIPTION
* Twisted shipped with 4.1 doesn't have reactor.suggestThreadPoolSize().
* 4.1 might not have the /Zenoss OSProcessOrganizer.