### PR TITLE
Add "blockingtimeout" option to zenpython.

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -9,7 +9,12 @@ This zenpack adds a new ''zenpython'' collector daemon. In most cases there is n
 The following options can be specified in the zenpython configuration file. Typically the default values for these options are appropriate and don't need to be adjusted.
 
 ;blockingwarning
-: The zenpython collector daemon executes plugin code provided by other ZenPacks. If this plugin code blocks for too long it will prevent zenpython from performing other tasks including collecting other datasources while the plugin code is executed. The ''blockingwarning'' option will cause zenpython to log a warning for any plugin code that blocks for the configured number of seconds or more. The default value is 30. Decimal precision such as 0.5 can be used.
+: The zenpython collector daemon executes plugin code provided by other ZenPacks. If this plugin code blocks for too long it will prevent zenpython from performing other tasks including collecting other datasources while the plugin code is executed. The ''blockingwarning'' option will cause zenpython to log a warning for any plugin code that blocks for the configured number of seconds or more. The default value is 3 seconds. Decimal precision such as 3.5 can be used.
+
+;blockingtimeout
+: See ''blockingwarning''. This option will cause zenpython to disable a plugin if it blocks for longer than the number of seconds specified. The zenpython daemon will restart itself after disabling the plugin to get unblocked. Events will be created indicating that some monitoring will not be performed due to disabled plugins on all affected devices. The default value is 5 seconds. Decimal precision such as 5.5 can be used.
+: A blocking plugin likely indicates a problem with the way the plugin was written. The author of the plugin should be contacted if this is seen. Zenoss support should be contacted if the plugin came from Zenoss.
+: Once a plugin is blocked, it will remain permanently blocked until its name is removed from either /var/zenoss/zenpython.blocked on Zenoss 5, or /opt/zenoss/var/zenpython.blocked on Zenoss 4. The zenpython service must be restarted after manual modifications to this file.
 
 ;twistedthreadpoolsize
 : Controls size of threads pool. Datasources can use multi-threading to run multiple requests in parallel. Increasing this value may boost performance at the cost of system memory used. The default value is 10.
@@ -304,6 +309,10 @@ class MyDataSourcePlugin(PythonDataSourcePlugin):
 </syntaxhighlight>
 
 == Changes ==
+
+;1.8.0
+* Add "blockingtimeout" option to zenpython. (ZEN-19219)
+* Change default "blockingwarning" from 30 to 3 seconds.
 
 ;1.7.2 (2015-08-27)
 * Add "blockingwarning" option to zenpython.

--- a/ZenPacks/zenoss/PythonCollector/__init__.py
+++ b/ZenPacks/zenoss/PythonCollector/__init__.py
@@ -9,6 +9,11 @@
 
 import Globals  # noqa
 
+import logging
+LOG = logging.getLogger('zen.PythonCollector')
+
+import os
+
 from Products.ZenModel.ZenPack import ZenPack as ZenPackBase
 from Products.ZenUtils.Utils import unused
 
@@ -21,6 +26,13 @@ class ZenPack(ZenPackBase):
         app.getDmdRoot('Processes').createOrganizer('Zenoss')
 
         super(ZenPack, self).install(app)
+
+        # zenpython.py must be executable for its optional watchdog to
+        # succesfully restart it.
+        try:
+            os.system('chmod 0755 {}'.format(self.path('zenpython.py')))
+        except Exception as e:
+            LOG.error("failed to make zenpython.py executable: %s", e)
 
 
 # Patch last to avoid import recursion problems.

--- a/ZenPacks/zenoss/PythonCollector/objects/objects.xml
+++ b/ZenPacks/zenoss/PythonCollector/objects/objects.xml
@@ -1,5 +1,19 @@
 <?xml version="1.0"?>
 <objects>
+<!-- ('', 'zport', 'dmd', 'Events', 'App', 'Zenoss', 'instances', 'zenpython-datasources-disabled') -->
+<object id='/zport/dmd/Events/App/Zenoss/instances/zenpython-datasources-disabled' module='Products.ZenEvents.EventClassInst' class='EventClassInst'>
+<property type="text" id="transform" mode="w" >
+</property>
+<property type="string" id="eventClassKey" mode="w" >
+zenpython-datasources-disabled
+</property>
+<property type="int" id="sequence" mode="w" >
+1001
+</property>
+<property type="string" id="example" mode="w" >
+Some monitoring for this device has been disabled due to problems detected in the following datasources: TemplateName/datasourceName
+</property>
+</object>
 <!-- ('', 'zport', 'dmd', 'Processes', 'Zenoss', 'osProcessClasses', 'zenpython') -->
 <object id='/zport/dmd/Processes/Zenoss/osProcessClasses/zenpython' module='Products.ZenModel.OSProcessClass' class='OSProcessClass'>
 <property type="string" id="name" mode="w" >

--- a/ZenPacks/zenoss/PythonCollector/plugins.py
+++ b/ZenPacks/zenoss/PythonCollector/plugins.py
@@ -9,60 +9,111 @@
 
 """PythonDataSourcePlugin implementations used for testing."""
 
+import logging
+LOG = logging.getLogger('zen.PythonCollector')
+
+import math
 import time
 
 from twisted.internet import defer, reactor, threads
 
 from .datasources.PythonDataSource import PythonDataSourcePlugin
 
+SINE_LENGTH = 7200
+
+
+def radians_from_timestamp(timestamp):
+    return (math.pi * 2) * ((timestamp % SINE_LENGTH) / SINE_LENGTH)
+
 
 class BaseTestPlugin(PythonDataSourcePlugin):
 
     """Abstract base class for test plugins."""
 
-    # Must be overridden in subclasses. Identifies tasks in logs.
-    task_label = None
+    offset = (SINE_LENGTH / 6)
 
     @classmethod
     def config_key(cls, datasource, context):
         return (
             context.device().id,
             datasource.getCycleTime(context),
-            cls.task_label,
+            datasource.id,
             )
+
+    def __init__(self, config):
+        self.datasource = config.datasources[0].datasource
+        self.cycletime = config.datasources[0].cycletime
+
+    def get_data(self):
+        ds = self.datasource
+
+        data = self.new_data()
+        data['events'].append({
+            'severity': 2,
+            'summary': 'test {} 1'.format(ds)})
+
+        now = time.time()
+        radians = radians_from_timestamp(now + self.offset)
+        data['values'][None]['{}_sin'.format(ds)] = math.sin(radians) * 50 + 50
+
+        return data
 
 
 class TestSleepMainPlugin(BaseTestPlugin):
 
-    """Plugin that sleeps on the main thread.
+    """Plugin that sleeps for just shy of cycletime on the main thread."""
 
-    You would never want to do this. This plugin exists to help test
-    zenpython's ability to handle misbehaving plugins.
-
-    """
-
-    task_label = 'sleepMain'
+    offset = (SINE_LENGTH / 6) * 1
 
     def collect(self, config):
-        time.sleep(10)
-        return defer.succeed(self.new_data())
+        LOG.info("%s.collect()", self.datasource)
+        time.sleep(self.cycletime - 1)
+        return defer.succeed(self.get_data())
+
+
+class TestOversleepMainPlugin(BaseTestPlugin):
+
+    """Plugin that sleeps for double cycletime on the main thread."""
+
+    offset = (SINE_LENGTH / 6) * 2
+
+    def collect(self, config):
+        LOG.info("%s.collect()", self.datasource)
+        time.sleep(self.cycletime * 2)
+        return defer.succeed(self.get_data())
 
 
 class TestSleepThreadPlugin(BaseTestPlugin):
 
-    """Plugin that sleeps in a thread.
+    """Plugin that sleeps for just shy of cycletime in a thread."""
 
-    This is OK because collect immediately returns a deferred.
-
-    """
-
-    task_label = 'sleepThread'
+    offset = (SINE_LENGTH / 6) * 3
 
     @defer.inlineCallbacks
     def collect(self, config):
+        LOG.info("%s.collect()", self.datasource)
+
         def inner():
-            time.sleep(10)
-            return self.new_data()
+            time.sleep(self.cycletime - 1)
+            return self.get_data()
+
+        r = yield threads.deferToThread(inner)
+        defer.returnValue(r)
+
+
+class TestOversleepThreadPlugin(BaseTestPlugin):
+
+    """Plugin that sleeps for double cycletime in a thread."""
+
+    offset = (SINE_LENGTH / 6) * 4
+
+    @defer.inlineCallbacks
+    def collect(self, config):
+        LOG.info("%s.collect()", self.datasource)
+
+        def inner():
+            time.sleep(self.cycletime * 2)
+            return self.get_data()
 
         r = yield threads.deferToThread(inner)
         defer.returnValue(r)
@@ -70,20 +121,37 @@ class TestSleepThreadPlugin(BaseTestPlugin):
 
 class TestSleepAsyncPlugin(BaseTestPlugin):
 
-    """Plugin that sleeps asynchronously.
+    """Plugin that sleeps asynchronously for just shy of cycletime."""
 
-    This is OK because collect immediately returns a deferred.
-
-    """
-
-    task_label = 'sleepAsync'
+    offset = (SINE_LENGTH / 6) * 5
 
     @defer.inlineCallbacks
     def collect(self, config):
+        LOG.info("%s.collect()", self.datasource)
+
         def async_sleep(seconds):
             d = defer.Deferred()
             reactor.callLater(seconds, d.callback, None)
             return d
 
-        yield async_sleep(10)
-        defer.returnValue(self.new_data())
+        yield async_sleep(self.cycletime - 1)
+        defer.returnValue(self.get_data())
+
+
+class TestOversleepAsyncPlugin(BaseTestPlugin):
+
+    """Plugin that sleeps asynchronously double cycletime."""
+
+    offset = (SINE_LENGTH / 6) * 6
+
+    @defer.inlineCallbacks
+    def collect(self, config):
+        LOG.info("%s.collect()", self.datasource)
+
+        def async_sleep(seconds):
+            d = defer.Deferred()
+            reactor.callLater(seconds, d.callback, None)
+            return d
+
+        yield async_sleep(self.cycletime * 2)
+        defer.returnValue(self.get_data())

--- a/ZenPacks/zenoss/PythonCollector/tests/test_watchdog.py
+++ b/ZenPacks/zenoss/PythonCollector/tests/test_watchdog.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""Tests for watchdog module."""
+
+import Globals  # NOQA: imported for side effects.
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+
+from ZenPacks.zenoss.PythonCollector import watchdog
+
+
+class TestWatchdog(unittest.TestCase):
+
+    def test_start_then_exit(self):
+        """Start and exit with a watchdog started.
+
+        We have a problem with the watchdog thread not terminating with the
+        main thread if this doesn't exit quickly with ExitCode.OK.
+
+        """
+        exitcode, _, _ = Scenario.run("start_then_exit")
+        self.assertEquals(exitcode, ExitCode.OK)
+
+    def test_start_then_ctrlc(self):
+        """Start then simulate a CTRL-C (KeyboardInterrupt).
+
+        We have a problem with the watchdog thread not terminating with the
+        main thread if this doesn't exit quickly with ExitCode.INTERRUPTED.
+
+        """
+        exitcode, _, _ = Scenario.run("start_then_ctrlc")
+        self.assertEquals(exitcode, ExitCode.INTERRUPTED)
+
+    def test_complete_before_timeout(self):
+        """Run an operation that will complete before the watchdog.timeout().
+
+        We have a problem with the watchdog being too aggressive if this
+        doesn't exit with ExitCode.OK. An ExitCode.KILLED would indicate that
+        the watchdog is repeatedly restarting the process so it can't reach
+        its own exit.
+
+        """
+        exitcode, _, _ = Scenario.run("complete_before_timeout")
+        self.assertEquals(exitcode, ExitCode.OK)
+
+    def test_timeout_before_complete(self):
+        """Run an operation that will exceed the watchdog.timeout().
+
+        Our scenario will kill the process and cause an ExitCode.KILLED if
+        this is functioning correctly because the watchdog will continually
+        restart the process and not let it get to its own exit.
+
+        We have a problem with the watchdog not restarting the if this results
+        in ExitCode.NOT_RESTARTED.
+
+        """
+        exitcode, _, _ = Scenario.run("timeout_before_complete")
+        self.assertEquals(exitcode, ExitCode.KILLED)
+
+    def test_timeout_file(self):
+        """Run and persist an operation that will exceed watchdog.timeout().
+
+        Our scenario will result in ExitCode.OK only if the watchdog correctly
+        stores the operation resulting in a timeout, restarts the process, and
+        is able to read the correct operation name from timeout_file.
+
+        We have a problem with the watchdog not restarting the process if this
+        results in ExitCode.NOT_RESTARTED.
+
+        We have a problem with the persisting and retrieval of the operation
+        that timed out if this results in ExitCode.KILLED.
+
+        """
+        exitcode, _, _ = Scenario.run("timeout_file")
+        self.assertEquals(exitcode, ExitCode.OK)
+
+
+class Scenario(object):
+
+    """Scenarios used in TestWatchdog test case.
+
+    The watchdog can only be observed and tested if its running in external
+    processes. The following scenarios should all be run via "run" so they
+    run in an external process.
+
+    """
+
+    @staticmethod
+    def run(scenario, seconds=5):
+        """Run named scenario in another process. Kill it after seconds.
+
+        Returns (exitcode, stdout, stderr)
+
+        """
+        p = subprocess.Popen(
+            [__file__, '--scenario', scenario],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE)
+
+        timer = threading.Timer(seconds, p.kill)
+        try:
+            timer.start()
+            stdout, stderr = p.communicate()
+        finally:
+            timer.cancel()
+
+        # The test runner complains about thread being left behind without
+        # this sleep.
+        time.sleep(0.1)
+
+        return (p.returncode, stdout, stderr)
+
+    @staticmethod
+    def start_then_exit():
+        """Start watchdog thread then exit."""
+        watchdog.start()
+
+        # Verify that watchdog did start.
+        for thread in threading.enumerate():
+            if thread.name == 'watchdog':
+                sys.exit(ExitCode.OK)
+
+        sys.exit(ExitCode.WATCHDOG_NOT_RUNNING)
+
+    @staticmethod
+    def start_then_ctrlc():
+        """Start the watchdog thread then simulate a CTRL-C."""
+        watchdog.start()
+        raise KeyboardInterrupt
+        sys.exit(ExitCode.OK)
+
+    @staticmethod
+    def complete_before_timeout():
+        """Complete opertion before timeout occurs."""
+        watchdog.start()
+        with watchdog.timeout(10, "complete_before_timeout"):
+            time.sleep(0.1)
+
+        sys.exit(ExitCode.OK)
+
+    @staticmethod
+    def timeout_before_complete():
+        """Timeout before operation completes."""
+        watchdog.start()
+        with watchdog.timeout(1, "timeout_before_complete"):
+            time.sleep(2)
+
+        sys.exit(ExitCode.NOT_RESTARTED)
+
+    @staticmethod
+    def timeout_file():
+        """Validate operation timeout is recorded and we're restarted."""
+        timeout_file = os.path.join(
+            tempfile.gettempdir(),
+            'test_watchdog.timeouts')
+
+        entries = watchdog.get_timeout_entries(timeout_file=timeout_file)
+        if os.path.isfile(timeout_file):
+            os.unlink(timeout_file)
+
+        if 'timeout_file' in entries:
+            sys.exit(ExitCode.OK)
+        else:
+            watchdog.start()
+            with watchdog.timeout(1, 'timeout_file'):
+                time.sleep(2)
+
+            sys.exit(ExitCode.NOT_RESTARTED)
+
+
+class ExitCode(object):
+    KILLED = -9
+    OK = 0
+    INTERRUPTED = 1
+    WATCHDOG_NOT_RUNNING = 2
+    NOT_RESTARTED = 3
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-s", "--scenario", help="the scenario to run")
+    args = parser.parse_args()
+
+    if args.scenario:
+        func = getattr(Scenario, args.scenario, None)
+        if not func:
+            sys.exit("{} is not a valid scenario.".format(args.scenario))
+        else:
+            func()
+    else:
+        unittest.main()
+
+
+if __name__ == '__main__':
+    main()

--- a/ZenPacks/zenoss/PythonCollector/watchdog.py
+++ b/ZenPacks/zenoss/PythonCollector/watchdog.py
@@ -1,0 +1,156 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+# These are the only symbols that should be used outside the module.
+__all__ = ['start', 'timeout', 'set_timeout_file', 'get_timeout_entries']
+
+
+import logging
+LOG = logging.getLogger('zen.watchdog')
+
+import contextlib
+import os
+import sys
+import threading
+import time
+
+
+def start():
+    Thread().start()
+
+
+@contextlib.contextmanager
+def timeout(seconds, name):
+    Thread.start_timer(name, seconds)
+    try:
+        yield
+    finally:
+        Thread.clear_timer()
+
+
+def set_timeout_file(timeout_file):
+    Thread.timeout_file = timeout_file
+
+
+def get_timeout_entries(timeout_file=None):
+    return Thread.get_timeout_entries(timeout_file=timeout_file)
+
+
+class Thread(threading.Thread):
+
+    # Name the thread in case it appears in tracebacks.
+    name = 'watchdog'
+
+    # This causes the thread to die when the main thread exits.
+    daemon = True
+
+    # Where operations that timed out are persisted between restarts.
+    timeout_file = None
+
+    # Details about the currently running operation.
+    op_name = None
+    op_timestamp = None
+    op_timeout = None
+
+    def run(self):
+        LOG.debug("started")
+        cls = self.__class__
+
+        while True:
+            # Wait to check for blocking until the timeout expires.
+            if all([cls.op_name, cls.op_timestamp, cls.op_timeout]):
+                timeout_time = cls.op_timestamp + cls.op_timeout
+                until_timeout = timeout_time - time.time()
+
+                if until_timeout > 0:
+                    time.sleep(until_timeout)
+
+                if cls.op_blocked():
+                    LOG.warning("timeout for %s", cls.op_name)
+                    cls.append_timeout_entry()
+                    LOG.warning("restarting process")
+                    self.restart_process()
+
+            # Wait for a second if no timer is currently running.
+            else:
+                time.sleep(1)
+
+    @classmethod
+    def start_timer(cls, name, seconds):
+        if seconds and seconds > 0:
+            cls.op_name = name
+            cls.op_timestamp = time.time()
+            cls.op_timeout = seconds
+
+    @classmethod
+    def clear_timer(cls):
+        cls.op_name = None
+        cls.op_timestamp = None
+        cls.op_timeout = None
+
+    @classmethod
+    def restart_process(cls):
+        try:
+            os.execv(sys.argv[0], sys.argv)
+        except Exception as e:
+            LOG.error("failed to restart process: %s", e)
+
+            # Reset op_timestamp to now. Otherwise we could get stuck in a
+            # tight loop forever trying to kill the process when we can't for
+            # some persistent reason. At least this way we will only attempt
+            # to restart the process at op_timeout intervals.
+            cls.op_timestamp = time.time()
+
+    @classmethod
+    def append_timeout_entry(cls):
+        if not cls.timeout_file or not cls.op_name:
+            return
+
+        state = cls.get_timeout_entries()
+        state.add(cls.op_name)
+
+        try:
+            with open(cls.timeout_file, 'w') as f:
+                f.write('{}\n'.format('\n'.join(state)))
+        except Exception as e:
+            LOG.error(
+                "failed to add %s to %s: %s",
+                cls.op_name, cls.timeout_file,
+                e)
+        else:
+            LOG.warning("added %s to %s", cls.op_name, cls.timeout_file)
+
+    @classmethod
+    def get_timeout_entries(cls, timeout_file=None):
+        if timeout_file:
+            cls.timeout_file = timeout_file
+
+        state = set()
+
+        if not cls.timeout_file:
+            return state
+
+        try:
+            with open(cls.timeout_file, 'r') as f:
+                for line in f:
+                    state.add(line.strip())
+        except Exception:
+            pass
+
+        return state
+
+    @classmethod
+    def op_blocked(cls):
+        if not cls.op_name or not cls.op_timeout:
+            return False
+
+        if (time.time() - cls.op_timestamp) > cls.op_timeout:
+            return True
+
+        return False

--- a/test-templates.yaml
+++ b/test-templates.yaml
@@ -1,4 +1,4 @@
-/Test-PythonCollector:
+/TestPythonCollector:
   description: Tests for PythonCollector.
 
   datasources:
@@ -7,12 +7,76 @@
       cycletime: 10
       plugin_classname: ZenPacks.zenoss.PythonCollector.plugins.TestSleepMainPlugin
 
+      datapoints:
+        sin: GAUGE_MIN_0_MAX_100
+
+    oversleepMain:
+      type: Python
+      cycletime: 10
+      plugin_classname: ZenPacks.zenoss.PythonCollector.plugins.TestOversleepMainPlugin
+
+      datapoints:
+        sin: GAUGE_MIN_0_MAX_100
+
     sleepThread:
       type: Python
       cycletime: 10
       plugin_classname: ZenPacks.zenoss.PythonCollector.plugins.TestSleepThreadPlugin
 
+      datapoints:
+        sin: GAUGE_MIN_0_MAX_100
+
+    oversleepThread:
+      type: Python
+      cycletime: 10
+      plugin_classname: ZenPacks.zenoss.PythonCollector.plugins.TestOversleepThreadPlugin
+
+      datapoints:
+        sin: GAUGE_MIN_0_MAX_100
+
     sleepAsync:
       type: Python
       cycletime: 10
       plugin_classname: ZenPacks.zenoss.PythonCollector.plugins.TestSleepAsyncPlugin
+
+      datapoints:
+        sin: GAUGE_MIN_0_MAX_100
+
+    oversleepAsync:
+      type: Python
+      cycletime: 10
+      plugin_classname: ZenPacks.zenoss.PythonCollector.plugins.TestOversleepAsyncPlugin
+
+      datapoints:
+        sin: GAUGE_MIN_0_MAX_100
+
+  graphs:
+    Test Values:
+      units: arbitrary
+      miny: 0
+      maxy: 100
+
+      graphpoints:
+        sleepMain:
+          dpName: sleepMain_sin
+          format: "%5.0lf"
+
+        oversleepMain:
+          dpName: oversleepMain_sin
+          format: "%5.0lf"
+
+        sleepThread:
+          dpName: sleepThread_sin
+          format: "%5.0lf"
+
+        oversleepThread:
+          dpName: oversleepThread_sin
+          format: "%5.0lf"
+
+        sleepAsync:
+          dpName: sleepAsync_sin
+          format: "%5.0lf"
+
+        oversleepAsync:
+          dpName: oversleepAsync_sin
+          format: "%5.0lf"


### PR DESCRIPTION
Review CC: @kcashman, @vserheiev

The blockingtimeout option allows plugins that block to be disabled if
their collect method blocks for longer than "blockingtimeout" which
defaults to 5 seconds.

Fixes ZEN-19219.