### PR TITLE
Added twistedconcurrenthttp configuration option.  This limits overal…

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -19,6 +19,9 @@ The following options can be specified in the zenpython configuration file. Typi
 ;twistedthreadpoolsize
 : Controls size of threads pool. Datasources can use multi-threading to run multiple requests in parallel. Increasing this value may boost performance at the cost of system memory used. The default value is 10.
 
+;twistedconcurrenthttp
+: Controls the number of total concurrent HTTP connections to be permitted by the twisted.web.client.getPage function.
+
 ;collect
 : Allows only specific plugins to run. This is primarily a developer option to help reduce the noise while developing plugins. The default is to collect all configured plugins. The value for this option is a regular expression. Only plugins which class name matches the regular expression will be run.
 
@@ -309,6 +312,10 @@ class MyDataSourcePlugin(PythonDataSourcePlugin):
 </syntaxhighlight>
 
 == Changes ==
+
+;1.8.0 (2016-01-19)
+* Add 'twistedconcurrenthttp' option to zenpython
+* Add ZenPacks.zenoss.PythonCollector.web.client.getPage() API
 
 ;1.7.3 (2015-11-25)
 * Add "blockingtimeout" option to zenpython. (ZEN-19219)

--- a/ZenPacks/zenoss/PythonCollector/patches/getPage.py
+++ b/ZenPacks/zenoss/PythonCollector/patches/getPage.py
@@ -1,0 +1,25 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import twisted.web.client as txwebclient
+
+from Products.ZenUtils.Utils import monkeypatch, unused
+from ZenPacks.zenoss.PythonCollector.web.semaphores import getOverallDeferredSemaphore
+
+unused(txwebclient)
+
+
+@monkeypatch('twisted.web.client')
+def getPage(*args, **kwargs):
+
+    # Overall limit on concurrent queries
+    semaphore = getOverallDeferredSemaphore()
+
+    # original is injected by the @monkeypatch decorator.
+    return semaphore.run(original, *args, **kwargs)

--- a/ZenPacks/zenoss/PythonCollector/web/client.py
+++ b/ZenPacks/zenoss/PythonCollector/web/client.py
@@ -1,0 +1,207 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import logging
+import os
+import random
+from twisted.internet import defer, reactor
+from twisted.internet.error import DNSLookupError
+from twisted.web import http, client as txwebclient
+from urlparse import urlunparse
+from .semaphores import getOverallDeferredSemaphore, getKeyedDeferredSemaphore
+
+log = logging.getLogger('zen.python.web.client')
+
+
+# Supports getPage functionality, but honors proxy environment variables
+class ProxyWebClient(object):
+    """web methods with proxy support."""
+
+    def __init__(self, url, username=None, password=None, return_headers=False):
+        # get scheme used by url
+        scheme, host, port, path = self.url_parse(url)
+        envname = '%s_proxy' % scheme
+        self.use_proxy = False
+        self.proxy_host = None
+        self.proxy_port = None
+        if envname in os.environ.keys():
+            proxy = os.environ.get('%s_proxy' % scheme)
+            if proxy:
+                # using proxy server
+                # host:port identifies a proxy server
+                # url is the actual target
+                self.use_proxy = True
+                scheme, host, port, path = self.url_parse(proxy)
+                self.proxy_host = host
+                self.proxy_port = port
+                self.username = username
+                self.password = password
+        else:
+            self.host = host
+            self.port = port
+        self.path = url
+        self.url = url
+        self.return_headers = return_headers
+
+    def url_parse(self, url, defaultPort=None):
+        """
+        Split the given URL into the scheme, host, port, and path.
+
+        @type url: C{str}
+        @param url: An URL to parse.
+
+        @type defaultPort: C{int} or C{None}
+        @param defaultPort: An alternate value to use as the port if the URL does
+        not include one.
+
+        @return: A four-tuple of the scheme, host, port, and path of the URL.  All
+        of these are C{str} instances except for port, which is an C{int}.
+        """
+        url = url.strip()
+        parsed = http.urlparse(url)
+        scheme = parsed[0]
+        path = urlunparse(('', '') + parsed[2:])
+
+        if defaultPort is None:
+            if scheme == 'https':
+                defaultPort = 443
+            else:
+                defaultPort = 80
+
+        host, port = parsed[1], defaultPort
+        if ':' in host:
+            host, port = host.split(':')
+            try:
+                port = int(port)
+            except ValueError:
+                port = defaultPort
+
+        if path == '':
+            path = '/'
+
+        return scheme, host, port, path
+
+    def get_page(self, contextFactory=None, description=None, *args, **kwargs):
+        if description is None:
+            description = self.url
+
+        scheme, _, _, _ = self.url_parse(self.url)
+        factory = txwebclient.HTTPClientFactory(self.url, *args, **kwargs)
+        if scheme == 'https':
+            from twisted.internet import ssl
+            if contextFactory is None:
+                contextFactory = ssl.ClientContextFactory()
+            if self.use_proxy:
+                reactor.connectSSL(self.proxy_host, self.proxy_port,
+                                   factory, contextFactory)
+            else:
+                reactor.connectSSL(self.host, self.port,
+                                   factory, contextFactory)
+        else:
+            if self.use_proxy:
+                reactor.connectTCP(self.proxy_host, self.proxy_port, factory)
+            else:
+                reactor.connectTCP(self.host, self.port, factory)
+
+        if self.return_headers:
+            return factory.deferred.addCallback(
+                lambda page: (page, factory.response_headers))
+        else:
+            return factory.deferred
+
+
+@defer.inlineCallbacks
+def getPage(url, return_headers=False, concurrent_key=None, concurrent_limit=None, max_retries=1, retry_status_codes=None, description=None, *args, **kwargs):
+    '''
+    Retrieve a URL, in a manner that is backwards compatible with
+    twisted.web.client.getPage.   Unlike the default getPage, the http proxy
+    environment variables are supported.
+
+    - retry_status_codes (default: 400, 408, 500, 502, 503, 504)  - list of
+           status codes that trigger a retry, if max_retries > 1.
+    - max_retries (default: 1)  if one of the retry_status_codes is returned,
+           retry the request up to this many times, with exponential backoff.
+    - concurrent_limit (default: None): number of concurrent connections to allow
+           for the specified concurrent_key.
+    - concurrent_key (default: None): an identifier to use for managing
+           concurrency.  For instance, this could be a hostname, or a tuple of
+           identifiers.
+    - return_headers (default: False)  If true, returns a tuple of
+           (body, http response headers) rather than just the body content.
+    '''
+
+    if retry_status_codes is None:
+        retry_status_codes = (
+            400,  # Bad Request  (retry is unlikely to help, but it should be harmless to try)
+            408,  # Request Timeout
+            500,  # Internal Server Error
+            502,  # Bad Gateway
+            503,  # Service Unavailable
+            504)  # Gateway Timeout
+
+    if description is None:
+        description = url
+    kwargs['description'] = description
+
+    # Overall limit on concurrent queries
+    overall_semaphore = getOverallDeferredSemaphore()
+
+    # Limit concurrent queries based on concurrent_key and concurrent_limit as
+    # well, if specified.
+    keyed_semaphore = None
+    if concurrent_key is not None and concurrent_limit is not None:
+        keyed_semaphore = getKeyedDeferredSemaphore(concurrent_key, concurrent_limit)
+
+    factory = ProxyWebClient(url, return_headers=return_headers)
+
+    def sleep(secs):
+        d = defer.Deferred()
+        reactor.callLater(secs, d.callback, None)
+        return d
+
+    # Incremental backoff
+    for retry in xrange(max_retries + 1):
+        if retry > 0:
+            delay = (random.random() * pow(4, retry)) / 10.0
+            log.debug(
+                '%s retry %s backoff is %s seconds',
+                description, retry, delay)
+
+            yield sleep(delay)
+
+        try:
+            def get_page():
+                if keyed_semaphore:
+                    return keyed_semaphore.run(factory.get_page, *args, **kwargs)
+                else:
+                    return factory.get_page(*args, **kwargs)
+
+            result = yield overall_semaphore.run(get_page)
+
+        except DNSLookupError, e:
+            # These could be transient, so go ahead and retry.
+            log.warning("DNS Error: %s" % str(e))
+            continue
+
+        except Exception, ex:
+            code = getattr(ex, 'status', None)
+
+            if code in retry_status_codes:
+                if int(code) < 500:
+                    # A 4xx error is pretty unusual, so log them, just in case.
+                    log.warning("HTTP Error (%s): %s - retrying." % (url, str(ex)))
+
+                continue
+
+            # any other exception, we can't recover, so give up.
+            raise
+
+        else:
+            defer.returnValue(result)
+            break

--- a/ZenPacks/zenoss/PythonCollector/web/semaphores.py
+++ b/ZenPacks/zenoss/PythonCollector/web/semaphores.py
@@ -1,0 +1,74 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import logging
+import time
+import zope.interface
+from twisted.internet import defer
+from Products.ZenCollector.interfaces import ICollectorPreferences
+from Products.ZenUtils import Map
+
+log = logging.getLogger('zen.python.web.semaphores')
+
+
+DEFAULT_TWISTEDCONCURRENTHTTP = 512
+
+
+class ExpiringSemaphoreMap(Map.Timed):
+    def clean(self, now=None):
+        "remove old values"
+
+        if now is None:
+            now = time.time()
+        if self.lastClean + self.timeout > now:
+            return
+        for k, (v, t) in self.map.items():
+            # only allow them to expire if they are not being used
+            if t + self.timeout < now and self.map[k].tokens == 0:
+                del self.map[k]
+        self.lastClean = now
+
+
+# Global semaphore tracking
+OVERALL_SEMAPHORE = None
+KEYED_SEMAPHORES = ExpiringSemaphoreMap({}, 15 * 60)
+
+
+def getOverallDeferredSemaphore():
+    global OVERALL_SEMAPHORE
+
+    if OVERALL_SEMAPHORE is None:
+        preferences = zope.component.queryUtility(
+            ICollectorPreferences, 'zenpython')
+
+        if preferences:
+            OVERALL_SEMAPHORE = defer.DeferredSemaphore(preferences.options.twistedconcurrenthttp)
+        else:
+            # When we are running in a daemon other than zenpython, the preferences
+            # value will not be available
+            OVERALL_SEMAPHORE = defer.DeferredSemaphore(DEFAULT_TWISTEDCONCURRENTHTTP)
+
+    return OVERALL_SEMAPHORE
+
+
+def getKeyedDeferredSemaphore(key, limit):
+    global KEYED_SEMAPHORES
+
+    if key not in KEYED_SEMAPHORES:
+        KEYED_SEMAPHORES[key] = defer.DeferredSemaphore(limit)
+    semaphore = KEYED_SEMAPHORES[key]
+
+    if semaphore.limit != limit:
+        if limit >= semaphore.tokens:
+            semaphore.limit = limit
+            log.info("Unable to lower maximum parallel query limit for %s to %d ", key, limit)
+        else:
+            log.warning("Unable to lower maximum parallel query limit for %s to %d at this time (%d connections currently active)", key, limit, semaphore.tokens)
+
+    return semaphore

--- a/ZenPacks/zenoss/PythonCollector/zenpython.py
+++ b/ZenPacks/zenoss/PythonCollector/zenpython.py
@@ -71,6 +71,7 @@ from Products.ZenUtils.Utils import unused
 from ZenPacks.zenoss.PythonCollector import watchdog
 from ZenPacks.zenoss.PythonCollector.utils import get_dp_values
 from ZenPacks.zenoss.PythonCollector.services.PythonConfig import PythonDataSourceConfig
+from ZenPacks.zenoss.PythonCollector.web.semaphores import DEFAULT_TWISTEDCONCURRENTHTTP
 
 try:
     from Products.ZenUtils.Utils import varPath
@@ -83,7 +84,10 @@ except ImportError:
         return zenPath(*all_args)
 
 
-unused(Globals)
+# patch twisted.web.client.getPage
+import ZenPacks.zenoss.PythonCollector.patches.getPage as gp
+
+unused(Globals, gp)
 
 pb.setUnjellyableForClass(PythonDataSourceConfig, PythonDataSourceConfig)
 
@@ -135,6 +139,13 @@ class Preferences(object):
             '--ignore',
             dest='ignorePlugins', default="",
             help="Python plugins to ignore. Takes a regular expression")
+
+        parser.add_option(
+            '--twistedconcurrenthttp',
+            dest='twistedconcurrenthttp',
+            type='int',
+            default=DEFAULT_TWISTEDCONCURRENTHTTP,
+            help="Overall limit of concurrent HTTP connections by all plugins which utilize ZenPacks.zenoss.PythonCollector.web.client.getPage")
 
     def postStartup(self):
         if self.options.ignorePlugins and self.options.collectPlugins:


### PR DESCRIPTION
…l HTTP calls made

by twisted.web.client.getPage or ZenPacks.zenoss.PythonCollector.web.client.getPage.

Added ZenPacks.zenoss.PythonCollector.web.client.getPage, which is a drop-in
replacement for standard getPage, but adds funcitonality:
  * concurrent_limit and concurrent_key options further retrict concurrent connections based on a user-supplied key, which could be a hostname, for instance.
  * support for HTTP/HTTPS proxy environment variables
  * available retry/backoff logic when errors are encountered.