### PR TITLE
Increase default blockingtimeout to 30 seconds

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -12,7 +12,7 @@ The following options can be specified in the zenpython configuration file. Typi
 : The zenpython collector daemon executes plugin code provided by other ZenPacks. If this plugin code blocks for too long it will prevent zenpython from performing other tasks including collecting other datasources while the plugin code is executed. The ''blockingwarning'' option will cause zenpython to log a warning for any plugin code that blocks for the configured number of seconds or more. The default value is 3 seconds. Decimal precision such as 3.5 can be used.
 
 ;blockingtimeout
-: See ''blockingwarning''. This option will cause zenpython to disable a plugin if it blocks for longer than the number of seconds specified. The zenpython daemon will restart itself after disabling the plugin to get unblocked. Events will be created indicating that some monitoring will not be performed due to disabled plugins on all affected devices. The default value is 5 seconds. Decimal precision such as 5.5 can be used.
+: See ''blockingwarning''. This option will cause zenpython to disable a plugin if it blocks for longer than the number of seconds specified. The zenpython daemon will restart itself after disabling the plugin to get unblocked. Events will be created indicating that some monitoring will not be performed due to disabled plugins on all affected devices. The default value is 30 seconds. Decimal precision such as 5.5 can be used.
 : A blocking plugin likely indicates a problem with the way the plugin was written. The author of the plugin should be contacted if this is seen. Zenoss support should be contacted if the plugin came from Zenoss.
 : Once a plugin is blocked, it will remain permanently blocked until its name is removed from either /var/zenoss/zenpython.blocked on Zenoss 5, or /opt/zenoss/var/zenpython.blocked on Zenoss 4. The zenpython service must be restarted after manual modifications to this file.
 
@@ -309,6 +309,9 @@ class MyDataSourcePlugin(PythonDataSourcePlugin):
 </syntaxhighlight>
 
 == Changes ==
+
+;1.7.4
+* Increase default blockingtimeout from 5 to 30 seconds. (ZEN-22632)
 
 ;1.7.3 (2015-11-25)
 * Add "blockingtimeout" option to zenpython. (ZEN-19219)

--- a/ZenPacks/zenoss/PythonCollector/zenpython.py
+++ b/ZenPacks/zenoss/PythonCollector/zenpython.py
@@ -116,7 +116,7 @@ class Preferences(object):
             '--blockingtimeout',
             dest='blockingTimeout',
             type='float',
-            default=5.0,
+            default=30.0,
             help="Disable plugins that block for X seconds")
 
         parser.add_option(


### PR DESCRIPTION
The previous default value of 5 seconds is causing too many field issues
with datasource plugins that are written about as asynchronously as
possible.

Fixes ZEN-22632.