### PR TITLE
ZEN-23167: Bad device config results in silent faliure on device

### DIFF
--- a/ZenPacks/zenoss/PythonCollector/datasources/PythonDataSource.py
+++ b/ZenPacks/zenoss/PythonCollector/datasources/PythonDataSource.py
@@ -91,7 +91,11 @@ class PythonDataSource(ZenPackPersistence, RRDDataSource):
         if not self.plugin_classname:
             return {}
 
-        return self.getPluginClass().params(self, context)
+        try:
+            params = self.getPluginClass().params(self, context)
+        except AttributeError:
+            params = {}
+        return params
 
 
 class IPythonDataSourceInfo(IRRDDataSourceInfo):


### PR DESCRIPTION
The issue in ZEN-23167 is that a user has added a "Windows Process" datasource to a template that is bound to a device. So it's just a bad configuration that makes no sense for the plugin to collect. The bug is that when PythonDataSourcePlugin.params raises an exception, it prevents a config from being built for the device at all. So all zenpython collection from the device would be prevented.