### PR TITLE
Fix test_timeout_file unit test

### DIFF
--- a/ZenPacks/zenoss/PythonCollector/tests/test_watchdog.py
+++ b/ZenPacks/zenoss/PythonCollector/tests/test_watchdog.py
@@ -108,7 +108,7 @@ class Scenario(object):
         os.chmod(file, st.st_mode | xa)
 
     @staticmethod
-    def run(scenario, seconds=5):
+    def run(scenario, seconds=10):
         """Run named scenario in another process. Kill it after seconds.
 
         Returns (exitcode, stdout, stderr)


### PR DESCRIPTION
No code issue. In some instances this test would fail due to a simple
timing issue. Adding another 5 seconds of buffer should make this test
pass on slower or burdened systems.

This will only fix ZEN-24652 once PythonCollector 1.8.2 is release with
the fix.