### PR TITLE
add @translateError to PythonConfig.applyDataMaps

### DIFF
--- a/ZenPacks/zenoss/PythonCollector/services/PythonConfig.py
+++ b/ZenPacks/zenoss/PythonCollector/services/PythonConfig.py
@@ -16,6 +16,7 @@ from twisted.spread import pb
 
 from Products.DataCollector.ApplyDataMap import ApplyDataMap
 from Products.ZenCollector.services.config import CollectorConfigService
+from Products.ZenHub.PBDaemon import translateError
 from Products.ZenRRD.zencommand import DataPointConfig
 from Products.ZenUtils.ZenTales import talesEvalStr
 
@@ -224,6 +225,7 @@ class PythonConfig(CollectorConfigService):
                         break
         return result
 
+    @translateError
     def remote_applyDataMaps(self, device, datamaps):
         device_obj = self.getPerformanceMonitor().findDevice(device)
         if device_obj is None:


### PR DESCRIPTION
Without the @translateError decorator, zenpython doesn't get a full
traceback when there's an exception in the method. It'll look something
like this.

    2019-05-21 19:46:50,835 ERROR zen.python: testrail.zenoss.loc 300 MySQLDatabase DbStats ZenPacks.zenoss.MySqlMonitor.dsplugins.MySQLMonitorDatabasesPlugin lost 5 datamaps
    Traceback (most recent call last):
      File "/mnt/src/ZenPacks.zenoss.PythonCollector/ZenPacks/zenoss/PythonCollector/zenpython.py", line 635, in applyMaps
        'applyDataMaps', self.configId, maps)
    RemoteError: getattr(): attribute name must be string

This usually isn't enough to diagnose and fix the cause of the
exception. With the @translateError decorator you will see the following
instead.

    2019-05-22 19:38:46,991 ERROR zen.python: testrail.zenoss.loc 300 MySQLDatabase DbStats ZenPacks.zenoss.MySqlMonitor.dsplugins.MySQLMonitorDatabasesPlugin lost 5 datamaps
    Traceback (most recent call last):
      File "/mnt/src/ZenPacks.zenoss.PythonCollector/ZenPacks/zenoss/PythonCollector/zenpython.py", line 635, in applyMaps
        'applyDataMaps', self.configId, maps)
    RemoteException: : Traceback (most recent call last):
      File "/opt/zenoss/Products/ZenHub/PBDaemon.py", line 109, in inner
        return callable(*args, **kw)
      File "/mnt/src/ZenPacks.zenoss.PythonCollector/ZenPacks/zenoss/PythonCollector/services/PythonConfig.py", line 238, in remote_applyDataMaps
        if applicator._applyDataMap(device_obj, datamap):
      File "/opt/zenoss/Products/DataCollector/ApplyDataMap/applydatamap.py", line 140, in applyDataMap
        result = transact(adm_method)(datamap, device)
      File "/opt/zenoss/lib/python2.7/site-packages/ZODB/transact.py", line 44, in g
        r = f(*args, **kwargs)
      File "/opt/zenoss/Products/DataCollector/ApplyDataMap/applydatamap.py", line 174, in _apply_incrementalmap
        return incremental_map.apply()
      File "/opt/zenoss/Products/DataCollector/ApplyDataMap/incrementalupdate.py", line 94, in apply
        ret = self._directive_map[self.directive]()
      File "/opt/zenoss/Products/DataCollector/ApplyDataMap/incrementalupdate.py", line 308, in _rebuild
        self._remove()
      File "/opt/zenoss/Products/DataCollector/ApplyDataMap/incrementalupdate.py", line 271, in _remove
        self.parent.removeRelation(self.relname, self.target)
      File "/opt/zenoss/Products/ZenRelations/RelationshipManager.py", line 131, in removeRelation
        rel = getattr(self, name, None)
    TypeError: getattr(): attribute name must be string

This is usually enough to diagnose and fix the problem.

Fixes ZPS-5833.