### PR TITLE
fix "getTags() takes exactly 1 argument (2 given)"

### DIFF
--- a/ZenPacks/zenoss/PythonCollector/services/PythonConfig.py
+++ b/ZenPacks/zenoss/PythonCollector/services/PythonConfig.py
@@ -129,7 +129,7 @@ class PythonConfig(CollectorConfigService):
                         dp_config.metadata = deviceOrComponent.getMetricMetadata()
 
                     # Support for RRDDataPoint.tags added in Zenoss 7.
-                    if hasattr(dp, "getTags"):
+                    if dp.aqBaseHasAttr("getTags"):
                         dp_config.tags = dp.getTags(deviceOrComponent)
                     else:
                         dp_config.tags = {}


### PR DESCRIPTION
When I added tag support to datapoints in (ZPS-4629 | #58 | 00e705d), I
didn't account for the fact that objects in the datapoint's acquisition
path could have a getTags attribute. It turns out that datapoints on
some AWS components would acquire the getTags attribute from their
component and cause the following traceback while building
configurations for zenpython.

    Traceback (most recent call last):
      File "/opt/zenoss/Products/ZenCollector/services/config.py", line 125, in _wrapFunction
        return functor(*args, **kwargs)
      File "/opt/zenoss/Products/ZenCollector/services/config.py", line 297, in _createDeviceProxies
        proxy = self._createDeviceProxy(device)
      File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.PythonCollector-1.11.0.dev27+gc580d9a-py2.7.egg/ZenPacks/zenoss/PythonCollector/services/PythonConfig.py", line 74, in _createDeviceProxy
        self.component_datasources(component, collector))
      File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.PythonCollector-1.11.0.dev27+gc580d9a-py2.7.egg/ZenPacks/zenoss/PythonCollector/services/PythonConfig.py", line 133, in _datasources
        dp_config.tags = dp.getTags(deviceOrComponent)
    TypeError: getTags() takes exactly 1 argument (2 given)

Fixes ZPS-5884.