### PR TITLE
ZPS-6719: multiple changes to fight memory leaks

### DIFF
--- a/ZenPacks/zenoss/PythonCollector/datasources/PythonDataSource.py
+++ b/ZenPacks/zenoss/PythonCollector/datasources/PythonDataSource.py
@@ -8,6 +8,7 @@
 ##############################################################################
 
 import collections
+import datetime
 import time
 
 from Acquisition import aq_base
@@ -119,7 +120,11 @@ class PythonDataSourceInfo(RRDDataSourceInfo):
 class PythonDataSourcePlugin(object):
     """Abstract base class for a PythonDataSourcePlugin."""
 
+    createdAt = None
     proxy_attributes = ()
+
+    def __init__(self):
+        self.createdAt = datetime.datetime.utcnow()
 
     @classmethod
     def config_key(cls, datasource, context):

--- a/ZenPacks/zenoss/PythonCollector/manhole.py
+++ b/ZenPacks/zenoss/PythonCollector/manhole.py
@@ -1,0 +1,73 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2019, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""Twisted manhole support.
+
+Allows SSH connections into the running process for troubleshooting purposes.
+
+"""
+
+from twisted import cred
+from twisted.conch import manhole, manhole_ssh
+from twisted.conch.insults import insults
+from twisted.conch.ssh.keys import Key
+from twisted.internet import reactor
+
+
+MANHOLE_PRIVATE_KEY = """
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEA4wso+ziJNL4m/C7ycjpDGVEIcutNdenoCRoUelOjyCXnoBIA
+fX61iUy0bNSQElewyQWhKvR/FuvxdzgDeukeNdjZC4ECzcm4SoP3my42Qx0Ye8+n
+xhpWMKW5rPGudTNGAJSrayals/Q8DQxWHZnTfH0YaImLnl5OC4CIcKeGh5vpgDyR
+72P4m+dRmocXnH/snyNlGmsOwTBCMiKV8pksxdjwmbxLhFmTCrrx/4IZpMHBB36q
+MqGvlVJ5+kkJg+MIOEq4q+UNJnQB4nW+DMTNfuwywV9YWb/wFTy3zCTRB9+NUjZ5
+kMhcbeSKCXXCUmdH0zvaOwEVirmcA92+17WvnQIDAQABAoIBACYEkmIuv1rjlGeZ
+/OL/uoictwt3N0tNVZtgkJlDNCOppTV6jjZ1ZzSMcZHfrhhEMsgWdzxYIIfYDmDm
+Mj78liByJTX17mBDLObdXjLP9CoczyK8TN2xP0l6FrNM7OeXJFuoiWOx3wFZHk0Z
+Cbp/LZik4ddvYL+uDueCKFak1rQSKLPaBr3o3znYNyFmMY0w/2WThFIxS0uyt6bw
+KrAXpj3F3S7O8WhSr71a4qsUWdT/kHZFo6jMK+0kJvuk+fbO4ByfOoaE3DJgoQP/
+D1cRF7GJfx3HUSU2FfdwUMLEIum0svNFHG3qEgEApbsmDjb5sEH4V4Qkn0WdZCaQ
+JQfhGokCgYEA8YhE00M30FUD63miZkEqw8N3i6P7iqgPIb2fA+WcnTcDooDnBU4D
+6MKvuhMvxXr6OVaWjc3b7oUzwpvhdS2RwRZ+/ZpctfmEoeHGztjCUP5tkfvOmX/B
+z4kdSjWs6/rNTOy0eeswml10fpHKct0kup9IJbVSCMCyV/k164l11k8CgYEA8KS3
+iF3kp32JAQjVsbKc2xHROR0ZTuMx8CC5d3NvR4jzv7wUHU/ySXhFcbr7kxH/w0Yz
+4aTVsYrqgXCCCtkG+wBn3FcEbZaLW/nGyntt9qHHcT8X7qlNUjM8rTNxpn1Jkeeh
+FA7iFSIO7+YPxmf3IIy5Td5HoLqd1E1dytBSjFMCgYB+IGnIZI6N1QdR/NeITDl3
+tugDXKNrWa1lMi8KiunI00SrpGJ/S6kQ8DFxmrlUh46JSKUf8cMKgDZyRpJqbVxy
+lzvDVMtbH6xaGJuHwntebi5rkDHnyGY96N0JtpPROsvggq8QB3f+9BR0T8+HQeH/
+LlQvlMr81RuMgw/cKpEFUwKBgDHv/KYv1eNsCaJNUwstJZ/QcrqHb1kPjK1oHRTM
+v6r4oJyJSyNKE91rN/4B73L1qT28s8d/jVjqmv+BeXsGzowH6YWwCRs0wnazvq0G
+MCueJuU5Up4URBdqyoymwE7scPf2OVcQP5pjFvZxp5RkvsPicBHYrsSL9XS5GV2d
+HYRBAoGBALNkTGTtZG3g5BrJ1cHnaWmstBBRQ+g9ISrdmxgP2qVQGRCl+y2ikPrO
+wtDFlhVzud1wOmTWuKCR2wYyUA3SOGk3vnYAqPJV1Bnw4iqsqIFQDxAnnxU2T9Gg
+7Q8KbcSz2ELLqPv/xL9THmq+LUC/SFZ5MXRGOyCzJ8uBEhYjf4UU
+-----END RSA PRIVATE KEY-----
+""".strip()
+
+MANHOLE_PUBLIC_KEY = """
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDjCyj7OIk0vib8LvJyOkMZUQhy60116egJGhR6U6PIJeegEgB9frWJTLRs1JASV7DJBaEq9H8W6/F3OAN66R412NkLgQLNybhKg/ebLjZDHRh7z6fGGlYwpbms8a51M0YAlKtrJqWz9DwNDFYdmdN8fRhoiYueXk4LgIhwp4aHm+mAPJHvY/ib51Gahxecf+yfI2Uaaw7BMEIyIpXymSzF2PCZvEuEWZMKuvH/ghmkwcEHfqoyoa+VUnn6SQmD4wg4Srir5Q0mdAHidb4MxM1+7DLBX1hZv/AVPLfMJNEH341SNnmQyFxt5IoJdcJSZ0fTO9o7ARWKuZwD3b7Xta+d
+""".strip()
+
+
+def setup(port, username, password):
+    checker = cred.checkers.InMemoryUsernamePasswordDatabaseDontUse()
+    checker.addUser(username, password)
+
+    realm = manhole_ssh.TerminalRealm()
+    realm.chainedProtocolFactory = lambda: insults.ServerProtocol(
+        manhole.ColoredManhole, {})
+
+    portal = cred.portal.Portal(realm)
+    portal.registerChecker(checker)
+
+    factory = manhole_ssh.ConchFactory(portal)
+    factory.privateKeys["ssh-rsa"] = Key.fromString(MANHOLE_PRIVATE_KEY)
+    factory.publicKeys["ssh-rsa"] = Key.fromString(MANHOLE_PUBLIC_KEY)
+
+    reactor.listenTCP(port, factory)

--- a/ZenPacks/zenoss/PythonCollector/utils.py
+++ b/ZenPacks/zenoss/PythonCollector/utils.py
@@ -12,6 +12,7 @@ import logging
 log = logging.getLogger('zen.python')
 
 from decimal import Decimal
+import weakref
 
 
 def get_dp_values(input_values):
@@ -73,3 +74,24 @@ def get_dp_ts(ts):
         return int(float(ts))
     except Exception:
         return
+
+
+def weakmethod(method, default=None):
+    """Return a function that only takes a weak reference to the object to which method is bound.
+
+    The returned function returns default if the original method's object no longer exists.
+
+    This can be used to avoid creating reference cycles.
+
+    """
+    self_ref = weakref.ref(method.im_self)
+    func = method.im_func
+
+    def weakcall(*args, **kwargs):
+        self = self_ref()
+        if self is None:
+            return default
+
+        return func(self, *args, **kwargs)
+
+    return weakcall

--- a/ZenPacks/zenoss/PythonCollector/zenpython.py
+++ b/ZenPacks/zenoss/PythonCollector/zenpython.py
@@ -18,8 +18,10 @@ import logging
 log = logging.getLogger('zen.python')
 
 import collections
+import datetime
 import functools
 import inspect
+import optparse
 import re
 
 import Globals
@@ -38,7 +40,7 @@ if __name__ == "__main__":
         installReactor()
 
 
-from twisted.internet import defer, reactor, task
+from twisted.internet import defer, error, reactor, task
 from twisted.internet.defer import inlineCallbacks, returnValue, maybeDeferred
 from twisted.python.failure import Failure
 from twisted.spread import pb
@@ -69,7 +71,8 @@ from Products.ZenUtils.Utils import unused
 
 from ZenPacks.zenoss.PythonCollector import twisted_utils
 from ZenPacks.zenoss.PythonCollector import watchdog
-from ZenPacks.zenoss.PythonCollector.utils import get_dp_values
+from ZenPacks.zenoss.PythonCollector import manhole
+from ZenPacks.zenoss.PythonCollector.utils import get_dp_values, weakmethod
 from ZenPacks.zenoss.PythonCollector.services.PythonConfig import PythonDataSourceConfig
 from ZenPacks.zenoss.PythonCollector.web.semaphores import DEFAULT_TWISTEDCONCURRENTHTTP
 from ZenPacks.zenoss.PythonCollector.lib.monotonic import monotonic
@@ -102,6 +105,11 @@ else:
 
 # eventClassKey for RUNNING timeout events.
 EVENTCLASSKEY_TIMEOUT = "zenpython-timeout"
+
+# Twisted manhole defaults.
+DEFAULT_MANHOLE_PORT = 7777
+DEFAULT_MANHOLE_USERNAME = 'zenoss'
+DEFAULT_MANHOLE_PASSWORD = 'zenoss'
 
 
 class Preferences(object):
@@ -166,12 +174,52 @@ class Preferences(object):
             default=None,
             help="Collect just for one datasource")
 
+        # Twisted manhole options. Disabled by default for security reasons.
+        manhole_group = optparse.OptionGroup(parser, "Manhole Options")
+        parser.add_option_group(manhole_group)
+
+        manhole_group.add_option(
+            '--manhole',
+            action='store_true',
+            default=False,
+            help='Enable Twisted manhole')
+
+        manhole_group.add_option(
+            '--manhole-port',
+            type='int',
+            default=DEFAULT_MANHOLE_PORT,
+            help='Twisted manhole port on which to listen (default %default)')
+
+        manhole_group.add_option(
+            '--manhole-username',
+            default=DEFAULT_MANHOLE_USERNAME,
+            help='Twisted manhole username (default %default)')
+
+        manhole_group.add_option(
+            '--manhole-password',
+            default=DEFAULT_MANHOLE_PASSWORD,
+            help='Twisted manhole password (default %default)')
+
     def postStartup(self):
         if self.options.ignorePlugins and self.options.collectPlugins:
             raise SystemExit("Only one of --ignore or --collect"
                              " can be used at a time")
 
+        self.setupManhole()
         self.setupWatchdog()
+
+    def setupManhole(self):
+        if self.options.manhole:
+            manhole_port = self.options.manhole_port
+            log.info("starting manhole on port %s", manhole_port)
+
+            try:
+                manhole.setup(
+                    port=manhole_port,
+                    username=self.options.manhole_username,
+                    password=self.options.manhole_password)
+            except error.CannotListenError as e:
+                log.error("failed to start manhole: %s", e)
 
     def setupWatchdog(self):
         if self.options.blockingTimeout > 0:
@@ -307,22 +355,6 @@ class PythonCollectionTask(BaseTask):
         # New in 1.7: Use startDelay from the plugin.
         self.startDelay = getattr(self.plugin, 'startDelay', None)
 
-        # New in 1.7.2: Wrap all calls to plugin methods in synchronous
-        # timeouts if "blockingtimeout" is non-zero. This is done to
-        # guard zenpython against plugins that pause the event loop with
-        # blocking code.
-        self.pluginCalls = {
-            x: self.wrapPluginCall(getattr(self.plugin, x))
-            for x in [
-                'collect',
-                'onResult',
-                'onSuccess',
-                'onError',
-                'onComplete',
-                'cleanup',
-            ]
-        }
-
         # New in 1.7.2: Track the percent of time zenpython is blocked
         # by plugin code. Plugin code should be asynchronous and the
         # amount of time they block should be very small. However, code
@@ -342,6 +374,9 @@ class PythonCollectionTask(BaseTask):
         # New in 1.11.0: Support for datapoint extra tags.
         self.metricExtraTags = getattr(
             self._dataService, "metricExtraTags", False)
+
+        # Useful for troubleshooting memory leaks.
+        self.createdAt = datetime.datetime.utcnow()
 
     def getDatasources(self):
         try:
@@ -384,29 +419,27 @@ class PythonCollectionTask(BaseTask):
         else:
             plugin = plugin_class()
 
-        # Provide access to getService, without providing access
-        # to other parts of self, or encouraging the use of
-        # self._collector, which you totally did not see.   Nothing
-        # to see here.  Move along.
-        @inlineCallbacks
-        def _getServiceFromCollector(service_name):
-            service = yield self._collector.getService(service_name)
-            returnValue(service)
+        default_r = defer.succeed(None)
 
-        plugin.getService = _getServiceFromCollector
+        # New in 1.6: All plugins to get hub services.
+        plugin.getService = weakmethod(self._collector.getService, default_r)
+
+        # New in 1.11: Allow plugins to change interval directly and immediately.
+        plugin.changeInterval = weakmethod(self.changeInterval)
 
         # New in 1.11: Allow plugins to directly and immediately publish data.
-        plugin.publishData = self.processResults
-        plugin.publishEvents = self.sendEvents
-        plugin.publishValues = self.storeValues
-        plugin.publishMetrics = self.publishMetrics
-        plugin.publishMaps = self.applyMaps
-        plugin.changeInterval = self.changeInterval
+        plugin.publishData = weakmethod(self.processResults, default_r)
+        plugin.publishEvents = weakmethod(self.sendEvents, default_r)
+        plugin.publishValues = weakmethod(self.storeValues, default_r)
+        plugin.publishMetrics = weakmethod(self.publishMetrics, default_r)
+        plugin.publishMaps = weakmethod(self.applyMaps, default_r)
 
         return plugin
 
-    def wrapPluginCall(self, f):
-        """Records detailed statistics for wrapped function."""
+    def wrapPluginCall(self, method):
+        """Records detailed statistics for wrapped plugin method."""
+        f = getattr(self.plugin, method)
+
         @functools.wraps(f)
         def __wrapper(*args, **kwargs):
             # Save original state to restore after running function.
@@ -495,7 +528,7 @@ class PythonCollectionTask(BaseTask):
 
         # Guard against plugin's collect method BLOCKING for too long.
         with watchdog.timeout(self.blockingTimeout, plugin_classname):
-            d = self.pluginCalls['collect'](self.config)
+            d = self.wrapPluginCall('collect')(self.config)
 
         # Guard against plugin's collect method RUNNING for too long.
         if self.runningTimeout:
@@ -505,10 +538,10 @@ class PythonCollectionTask(BaseTask):
                 exception_class=RunningTimeoutError)
 
         # Allow the plugin to handle results from it's collect method.
-        d.addBoth(self.pluginCalls['onResult'], self.config)
-        d.addCallback(self.pluginCalls['onSuccess'], self.config)
-        d.addErrback(self.pluginCalls['onError'], self.config)
-        d.addBoth(self.pluginCalls['onComplete'], self.config)
+        d.addBoth(self.wrapPluginCall('onResult'), self.config)
+        d.addCallback(self.wrapPluginCall('onSuccess'), self.config)
+        d.addErrback(self.wrapPluginCall('onError'), self.config)
+        d.addBoth(self.wrapPluginCall('onComplete'), self.config)
 
         # Have zenpython handle RunningTimeoutError if the plugin doesn't.
         if self.runningTimeout:
@@ -525,7 +558,7 @@ class PythonCollectionTask(BaseTask):
 
     def cleanup(self):
         try:
-            return self.pluginCalls['cleanup'](self.config)
+            return self.wrapPluginCall('cleanup')(self.config)
         except Exception as e:
             return self.handleError(e)
 
@@ -729,11 +762,11 @@ class PythonCollectionTask(BaseTask):
 
     def handleError(self, result):
         if isinstance(result, Failure):
-            error = result.value
+            e = result.value
         else:
-            error = result
+            e = result
 
-        log.error('%s unhandled plugin error: %s', self.name, error)
+        log.error('%s unhandled plugin error: %s', self.name, e)
 
 
 class RunningTimeoutError(Exception):

--- a/testing/ZenPacks.test.PythonCollector/ZenPacks/test/PythonCollector/plugins.py
+++ b/testing/ZenPacks.test.PythonCollector/ZenPacks/test/PythonCollector/plugins.py
@@ -275,7 +275,8 @@ class TestPublishedDataPlugin(PerDeviceTestPlugin):
         self.loop.start(10, now=False)
 
     def cleanup(self, config):
-        self.loop.stop()
+        if self.loop.running:
+            self.loop.stop()
 
     @defer.inlineCallbacks
     def onLoop(self, config):
@@ -283,7 +284,7 @@ class TestPublishedDataPlugin(PerDeviceTestPlugin):
             yield self.publishEvents([{
                 "component": datasource.component,
                 "severity": 2,
-                "summary": "TestReturnedDataPlugin {}".format(
+                "summary": "TestPublishedDataPlugin {}".format(
                     datasource.datasource)}])
 
             for point in datasource.points:
@@ -297,7 +298,7 @@ class TestPublishedDataPlugin(PerDeviceTestPlugin):
                     value=77.0,
                     tags={
                         "type": "adhoc",
-                        "plugin": "TestReturnedDataPlugin",
+                        "plugin": "TestPublishedDataPlugin",
                         "device": datasource.device,
                         "component": datasource.component})])
 

--- a/testing/ZenPacks.test.PythonCollector/ZenPacks/test/PythonCollector/zenpack.yaml
+++ b/testing/ZenPacks.test.PythonCollector/ZenPacks/test/PythonCollector/zenpack.yaml
@@ -113,6 +113,12 @@ device_classes:
               flaky:
                 dpName: flaky_sin
 
+              returned:
+                dpName: returnedData_value
+
+              published:
+                dpName: publishedData_value
+
       PythonCollectorComponent:
         targetPythonClass: ZenPacks.test.PythonCollector.PythonCollectorComponent
 

--- a/testing/ZenPacks.test.PythonCollector/setup.py
+++ b/testing/ZenPacks.test.PythonCollector/setup.py
@@ -3,7 +3,7 @@
 # or saved.  Do not modify them directly here.
 # NB: PACKAGES is deprecated
 NAME = "ZenPacks.test.PythonCollector"
-VERSION = "1.0.0dev"
+VERSION = "1.0.0"
 AUTHOR = "Your Name Here"
 LICENSE = ""
 NAMESPACE_PACKAGES = ['ZenPacks', 'ZenPacks.test']


### PR DESCRIPTION
Overview of changes:

- Fix reference cycles between PythonCollectionTask and its plugin.
- Replace twisted_utils.add_timeout() with Twisted's approach.
- Add built-in manhole support so we don't have to field-patch anymore.
- Add "createdAt" property to key objects so we can determine their age.

By using weak references from PythonCollectionTask's plugin back to the
task we can avoid keeping PythonCollectionTask instances around in
memory beyond their expected lifetime when the plugins have issues
preventing them from being freed.

I have no evidence that there was anything wrong with the
twisted_utils.add_timeout() function, but I found that newer versions of
Twisted come with a very similar function. So I remodeled our
implementation around theirs. I think it's at least better in that it
returns the same Deferred that is passed to it instead of creating
another one.

We've long patched several lines into zenpython's main function to
enable Twisted's manhole for troubleshooting purposes. I got tired of
doing this, and got even more tired of the shell not having basic
readline support. So I added proper manhole support to zenpython that
has proper readline support and syntax highlighting. Autocompletion
would be nice, but that didn't look trivial to add.

Adding the "createdAt" property to PythonCollectionTask and
PythonDataSourcePlugin instances allows us to much more quickly find
potential memory leaks using the manhole.